### PR TITLE
[CSE-50] Improve errors returned from failed tests

### DIFF
--- a/internal/app/api/api_test.go
+++ b/internal/app/api/api_test.go
@@ -182,7 +182,7 @@ func TestAPIClientDrainFeed_should_return_for_as_long_next_page_set(t *testing.T
 
 		rows := []map[string]string{}
 		err := json.Unmarshal(data.Data, &rows)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		for _, row := range rows {
 			auditIDs = append(auditIDs, row["id"])
@@ -190,7 +190,7 @@ func TestAPIClientDrainFeed_should_return_for_as_long_next_page_set(t *testing.T
 
 		return nil
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, 2, calls)
 	assert.Equal(t, []string{
@@ -399,7 +399,7 @@ func TestAPIClientDrainInspections_should_return_for_as_long_next_page_set(t *te
 			}
 			return nil
 		})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, []string{
 		"audit_8E2B1F3CB9C94D8792957F9F99E2E4BD",
@@ -422,11 +422,11 @@ func TestAPIClientGetInspection(t *testing.T) {
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	resp, err := apiClient.GetInspection(context.Background(), auditID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	rows := map[string]string{}
 	err = json.Unmarshal(*resp, &rows)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expected, ok := rows["audit_id"]
 	assert.Equal(t, true, ok)
@@ -550,7 +550,7 @@ func TestGetMediaWith403Error(t *testing.T) {
 			AuditID: "1234",
 		},
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGetMediaWith404Error(t *testing.T) {
@@ -571,7 +571,7 @@ func TestGetMediaWith404Error(t *testing.T) {
 			AuditID: "1234",
 		},
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGetMediaWith405Error(t *testing.T) {
@@ -614,7 +614,7 @@ func TestGetMediaWith204Error(t *testing.T) {
 			AuditID: "1234",
 		},
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, resp)
 }
 
@@ -665,7 +665,7 @@ func TestGetMedia(t *testing.T) {
 			AuditID: "1234",
 		},
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, resp, expected)
 }
 
@@ -688,7 +688,7 @@ func TestAPIClientInitiateInspectionReportExport_should_return_messageID(t *test
 
 	mId, err := apiClient.InitiateInspectionReportExport(context.Background(), "audit_123", "PDF", "p123")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "abc", mId)
 }
 
@@ -742,7 +742,7 @@ func TestAPIClientCheckInspectionReportExportCompletion_should_return_status(t *
 
 	res, err := apiClient.CheckInspectionReportExportCompletion(context.Background(), "audit_123", "abc")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, res.Status, "SUCCESS")
 	assert.Equal(t, res.URL, "http://domain.com/report")
 }
@@ -793,7 +793,7 @@ func TestAPIClientDownloadInspectionReportFile_should_return_status(t *testing.T
 
 	res, err := apiClient.DownloadInspectionReportFile(context.Background(), "http://localhost:9999/report-exports/abc")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(res)

--- a/internal/app/feed/export_csv_local_test.go
+++ b/internal/app/feed/export_csv_local_test.go
@@ -1,12 +1,13 @@
 package feed
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_FileExists_should_return_false_when_missing_file(t *testing.T) {
 	result, err := fileExists("xyz123")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, result)
 }

--- a/internal/app/feed/export_feeds_intg_test.go
+++ b/internal/app/feed/export_feeds_intg_test.go
@@ -25,9 +25,9 @@ import (
 
 func TestIntegrationDbCreateSchema_should_create_all_schemas(t *testing.T) {
 	sqlExporter, err := getTestingSQLExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	exporter, err := getTemporaryCSVExporterWithRealSQLExporter(sqlExporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
@@ -45,7 +45,7 @@ func TestIntegrationDbCreateSchema_should_create_all_schemas(t *testing.T) {
 		`)
 
 	err = feed.CreateSchemas(viperConfig, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	filesEqualish(t, "mocks/set_1/schemas/inspections.csv", filepath.Join(exporter.ExportPath, "inspections.csv"))
 	filesEqualish(t, "mocks/set_1/schemas/inspection_items.csv", filepath.Join(exporter.ExportPath, "inspection_items.csv"))
@@ -68,9 +68,9 @@ func TestIntegrationDbCreateSchema_should_create_all_schemas(t *testing.T) {
 
 func TestIntegrationDbExportFeeds_should_export_all_feeds_to_file(t *testing.T) {
 	sqlExporter, err := getTestingSQLExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	exporter, err := getTemporaryCSVExporterWithRealSQLExporter(sqlExporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
@@ -91,7 +91,7 @@ func TestIntegrationDbExportFeeds_should_export_all_feeds_to_file(t *testing.T) 
 		`)
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	filesEqualish(t, "mocks/set_1/outputs/inspections.csv", filepath.Join(exporter.ExportPath, "inspections.csv"))
 	filesEqualish(t, "mocks/set_1/outputs/inspection_items.csv", filepath.Join(exporter.ExportPath, "inspection_items.csv"))
@@ -116,9 +116,9 @@ func TestIntegrationDbExportFeeds_should_export_all_feeds_to_file(t *testing.T) 
 // and that other tables are incrementally updated
 func TestIntegrationDbExportFeeds_should_perform_incremental_update_on_second_run(t *testing.T) {
 	sqlExporter, err := getTestingSQLExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	exporter, err := getTemporaryCSVExporterWithRealSQLExporter(sqlExporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
@@ -145,12 +145,12 @@ func TestIntegrationDbExportFeeds_should_perform_incremental_update_on_second_ru
 		File(path.Join("mocks", "set_2", "inspections_deleted_single_page.json"))
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	initMockFeedsSet2(apiClient.HTTPClient())
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	filesEqualish(t, "mocks/set_2/outputs/inspections.csv", filepath.Join(exporter.ExportPath, "inspections.csv"))
 	filesEqualish(t, "mocks/set_2/outputs/inspection_items.csv", filepath.Join(exporter.ExportPath, "inspection_items.csv"))
@@ -173,9 +173,9 @@ func TestIntegrationDbExportFeeds_should_perform_incremental_update_on_second_ru
 
 func TestIntegrationDbExportFeeds_should_handle_lots_of_rows_ok(t *testing.T) {
 	sqlExporter, err := getTestingSQLExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	exporter, err := getTemporaryCSVExporterWithRealSQLExporter(sqlExporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
@@ -203,22 +203,22 @@ func TestIntegrationDbExportFeeds_should_handle_lots_of_rows_ok(t *testing.T) {
 		`)
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	inspectionsLines, err := countFileLines(filepath.Join(exporter.ExportPath, "inspections.csv"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 97, inspectionsLines)
 
 	inspectionItemsLines, err := countFileLines(filepath.Join(exporter.ExportPath, "inspection_items.csv"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 230, inspectionItemsLines)
 }
 
 func TestIntegrationDbExportFeeds_should_update_action_assignees_on_second_run(t *testing.T) {
 	sqlExporter, err := getTestingSQLExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	exporter, err := getTemporaryCSVExporterWithRealSQLExporter(sqlExporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
@@ -251,14 +251,14 @@ func TestIntegrationDbExportFeeds_should_update_action_assignees_on_second_run(t
 		File(path.Join("mocks", "set_1", "inspections_deleted_single_page.json"))
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	filesEqualish(t, "mocks/set_1/outputs/action_assignees.csv", filepath.Join(exporter.ExportPath, "action_assignees.csv"))
 
 	initMockFeedsSet2(apiClient.HTTPClient())
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	filesEqualish(t, "mocks/set_2/outputs/action_assignees.csv", filepath.Join(exporter.ExportPath, "action_assignees.csv"))
 }
 
@@ -268,7 +268,7 @@ func TestGroupUserFeed_Export_should_filter_duplicates(t *testing.T) {
 	require.NotNil(t, sqlExporter)
 
 	exporter, err := getTemporaryCSVExporterWithRealSQLExporter(sqlExporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
@@ -295,9 +295,9 @@ func TestGroupUserFeed_Export_should_filter_duplicates(t *testing.T) {
 		File("mocks/set_5/feed_group_users_1.json")
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	lines, err := countFileLines(filepath.Join(exporter.ExportPath, "group_users.csv"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 5, lines)
 }

--- a/internal/app/feed/export_feeds_soak_test.go
+++ b/internal/app/feed/export_feeds_soak_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestIntegrationDbSoakExportFeeds_should_successfully_export_with_significant_data(t *testing.T) {
 	exporter, err := getTestingSQLExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	exporter.AutoMigrate = true
 
 	fmt.Println(err, exporter)
@@ -27,5 +27,5 @@ func TestIntegrationDbSoakExportFeeds_should_successfully_export_with_significan
 	apiClient := api.NewClient(os.Getenv("TEST_API_HOST"), os.Getenv("TEST_ACCESS_TOKEN"))
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/internal/app/feed/export_feeds_test.go
+++ b/internal/app/feed/export_feeds_test.go
@@ -16,13 +16,13 @@ import (
 
 func TestCreateSchemas_should_create_all_schemas_to_file(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 	viperConfig.Set("export.site.include_deleted", true)
 
 	err = feed.CreateSchemas(viperConfig, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	filesEqualish(t, "mocks/set_1/schemas/inspections.csv", filepath.Join(exporter.ExportPath, "inspections.csv"))
 	filesEqualish(t, "mocks/set_1/schemas/inspection_items.csv", filepath.Join(exporter.ExportPath, "inspection_items.csv"))
@@ -45,7 +45,7 @@ func TestExportFeeds_should_export_all_feeds_to_file(t *testing.T) {
 	defer gock.Off()
 
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 	viperConfig.Set("export.site.include_deleted", true)
@@ -66,7 +66,7 @@ func TestExportFeeds_should_export_all_feeds_to_file(t *testing.T) {
 		`)
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	filesEqualish(t, "mocks/set_1/outputs/inspections.csv", filepath.Join(exporter.ExportPath, "inspections.csv"))
 	filesEqualish(t, "mocks/set_1/outputs/inspection_items.csv", filepath.Join(exporter.ExportPath, "inspection_items.csv"))
@@ -119,7 +119,7 @@ func TestExportFeeds_should_perform_incremental_update_on_second_run(t *testing.
 		File(path.Join("mocks", "set_2", "inspections_deleted_single_page.json"))
 
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
@@ -129,12 +129,12 @@ func TestExportFeeds_should_perform_incremental_update_on_second_run(t *testing.
 	initMockFeedsSet1(apiClient.HTTPClient())
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	initMockFeedsSet2(apiClient.HTTPClient())
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	filesEqualish(t, "mocks/set_2/outputs/inspections.csv", filepath.Join(exporter.ExportPath, "inspections.csv"))
 	filesEqualish(t, "mocks/set_2/outputs/inspection_items.csv", filepath.Join(exporter.ExportPath, "inspection_items.csv"))
@@ -186,7 +186,7 @@ func TestExportFeeds_should_handle_lots_of_rows_ok(t *testing.T) {
 	defer gock.Off()
 
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
@@ -213,13 +213,13 @@ func TestExportFeeds_should_handle_lots_of_rows_ok(t *testing.T) {
 		`)
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	inspectionsLines, err := countFileLines(filepath.Join(exporter.ExportPath, "inspections.csv"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 97, inspectionsLines)
 
 	inspectionItemsLines, err := countFileLines(filepath.Join(exporter.ExportPath, "inspection_items.csv"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 230, inspectionItemsLines)
 }

--- a/internal/app/feed/exporter_csv_test.go
+++ b/internal/app/feed/exporter_csv_test.go
@@ -1,12 +1,13 @@
 package feed_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/SafetyCulture/safetyculture-exporter/internal/app/feed"
 	"github.com/stretchr/testify/assert"
@@ -14,21 +15,21 @@ import (
 
 func TestCSVExporterSupportsUpsert_should_return_true(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.True(t, exporter.SupportsUpsert())
 }
 
 func TestCSVExporterInitFeed_should_create_table_if_not_exists(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// This query will only work for SQLite
 	result := []struct {
@@ -44,14 +45,14 @@ func TestCSVExporterInitFeed_should_create_table_if_not_exists(t *testing.T) {
 
 func TestCSVExporterInitFeed_should_truncate_table_if_truncate_is_true(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -62,12 +63,12 @@ func TestCSVExporterInitFeed_should_truncate_table_if_truncate_is_true(t *testin
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: true,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var rowCount int64
 	resp := exporter.DB.Table("users").Count(&rowCount)
@@ -77,14 +78,14 @@ func TestCSVExporterInitFeed_should_truncate_table_if_truncate_is_true(t *testin
 
 func TestCSVExporterInitFeed_should_not_truncate_table_if_truncate_is_false(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -95,12 +96,12 @@ func TestCSVExporterInitFeed_should_not_truncate_table_if_truncate_is_false(t *t
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var rowCount int64
 	resp := exporter.DB.Table("users").Count(&rowCount)
@@ -110,14 +111,14 @@ func TestCSVExporterInitFeed_should_not_truncate_table_if_truncate_is_false(t *t
 
 func TestCSVExporterWriteRows_should_write_rows(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -133,7 +134,7 @@ func TestCSVExporterWriteRows_should_write_rows(t *testing.T) {
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	rows := []feed.User{}
 	resp := exporter.DB.Table("users").Scan(&rows)
@@ -146,14 +147,14 @@ func TestCSVExporterWriteRows_should_write_rows(t *testing.T) {
 
 func TestCSVExporterWriteRows_should_update_rows(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: true,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -164,7 +165,7 @@ func TestCSVExporterWriteRows_should_update_rows(t *testing.T) {
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users = []feed.User{
 		{
@@ -175,7 +176,7 @@ func TestCSVExporterWriteRows_should_update_rows(t *testing.T) {
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	rows := []feed.User{}
 	resp := exporter.DB.Table("users").Scan(&rows)
@@ -189,14 +190,14 @@ func TestCSVExporterWriteRows_should_update_rows(t *testing.T) {
 
 func TestCSVExporterLastModifiedAt_should_return_latest_modified_at(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	inspectionFeed := &feed.InspectionFeed{}
 
 	err = exporter.InitFeed(inspectionFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	now := time.Now()
 	inspections := []feed.Inspection{
@@ -219,16 +220,16 @@ func TestCSVExporterLastModifiedAt_should_return_latest_modified_at(t *testing.T
 	}
 
 	err = exporter.WriteRows(inspectionFeed, inspections)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check the timestamp for the audits that doesn't have organisation_id
 	lastModifiedAt, err := exporter.LastModifiedAt(inspectionFeed, time.Now().Add(time.Hour*-30000), "role_123")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, convery to ISO string
 	assert.Equal(t, now.Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, time.Now().Add(time.Hour*-30000), "role_1234")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, convery to ISO string
 	assert.Equal(t, now.Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
@@ -256,30 +257,30 @@ func TestCSVExporterLastModifiedAt_should_return_latest_modified_at(t *testing.T
 	}
 
 	err = exporter.WriteRows(inspectionFeed, inspections)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check the timestamp for the audits that contains organisation_id
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, time.Now().Add(time.Hour*-30000), "role_123")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, convery to ISO string
 	assert.Equal(t, now.Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, time.Now().Add(time.Hour*-30000), "role_1234")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, convery to ISO string
 	assert.Equal(t, now.Add(time.Hour*-2).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 }
 
 func TestCSVExporterLastModifiedAt_should_return_modified_after_if_latest(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	inspectionFeed := &feed.InspectionFeed{}
 
 	err = exporter.InitFeed(inspectionFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	now := time.Now()
 	inspections := []feed.Inspection{
@@ -302,16 +303,16 @@ func TestCSVExporterLastModifiedAt_should_return_modified_after_if_latest(t *tes
 	}
 
 	err = exporter.WriteRows(inspectionFeed, inspections)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check the timestamp for the audits that doesn't have organisation_id
 	lastModifiedAt, err := exporter.LastModifiedAt(inspectionFeed, now.Add(time.Hour), "role_123")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, converting to ISO string
 	assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, now.Add(time.Hour), "role_124")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, converting to ISO string
 	assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
@@ -339,16 +340,16 @@ func TestCSVExporterLastModifiedAt_should_return_modified_after_if_latest(t *tes
 	}
 
 	err = exporter.WriteRows(inspectionFeed, inspections)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check the timestamp for the audits that contains organisation_id
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, now.Add(time.Hour), "role_123")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, converting to ISO string
 	assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, now.Add(time.Hour), "role_124")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, converting to ISO string
 	assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 }
@@ -368,7 +369,7 @@ func TestCSVExporter_should_do_rollover_files(t *testing.T) {
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -388,13 +389,13 @@ func TestCSVExporter_should_do_rollover_files(t *testing.T) {
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = exporter.FinaliseExport(userFeed, &[]feed.User{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(exporter.ExportPath, "users.csv"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	contentString := dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(content)), "--date--")
 
@@ -405,14 +406,14 @@ user_2,role_123,user.2@test.com,User 2,User 2,false,,--date--`
 
 func TestCSVExporterFinaliseExport_should_write_rows_out_to_file(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -432,7 +433,7 @@ func TestCSVExporterFinaliseExport_should_write_rows_out_to_file(t *testing.T) {
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users = []feed.User{
 		{
@@ -459,13 +460,13 @@ func TestCSVExporterFinaliseExport_should_write_rows_out_to_file(t *testing.T) {
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = exporter.FinaliseExport(userFeed, &[]feed.User{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(exporter.ExportPath, "users.csv"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	contentString := dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(content)), "--date--")
 
@@ -478,14 +479,14 @@ user_3,role_123,user.3@test.com,User 3,User 3,false,,--date--`
 
 func TestCSVExporterFinaliseExport_should_write_rows_to_multiple_file(t *testing.T) {
 	exporter, err := getTemporaryCSVExporterWithMaxRowsLimit(2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -512,17 +513,17 @@ func TestCSVExporterFinaliseExport_should_write_rows_to_multiple_file(t *testing
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = exporter.FinaliseExport(userFeed, &[]feed.User{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	files, err := filepath.Glob(filepath.Join(exporter.ExportPath, "users*.csv"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(files))
 
 	content1, err := os.ReadFile(files[0])
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	content1String := dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(content1)), "--date--")
 
@@ -532,7 +533,7 @@ user_2,role_123,user.2@test.com,User 2,User 2,false,,--date--`
 	assert.Equal(t, strings.TrimSpace(expected1), content1String)
 
 	content2, err := os.ReadFile(files[1])
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	content2String := dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(content2)), "--date--")
 

--- a/internal/app/feed/exporter_report_test.go
+++ b/internal/app/feed/exporter_report_test.go
@@ -31,7 +31,7 @@ func TestExportReports_should_export_all_reports(t *testing.T) {
 	defer gock.Off()
 
 	exporter, err := getTemporaryReportExporter([]string{"PDF", "WORD"}, "", "INSPECTION_TITLE")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
@@ -70,7 +70,7 @@ func TestExportReports_should_export_all_reports(t *testing.T) {
 		Body(bytes.NewBuffer([]byte(`file content`)))
 
 	err = feed.ExportInspectionReports(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	fileExists(t, filepath.Join(exporter.ExportPath, "My-Audit.pdf"))
 	fileExists(t, filepath.Join(exporter.ExportPath, "audit_4e28ab2cce8c44a781d376d0ac47dc92.pdf"))
@@ -85,7 +85,7 @@ func TestExportReports_should_export_all_reports_with_ID_filename(t *testing.T) 
 	defer gock.Off()
 
 	exporter, err := getTemporaryReportExporter([]string{"PDF", "WORD"}, "", "INSPECTION_ID")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
@@ -124,7 +124,7 @@ func TestExportReports_should_export_all_reports_with_ID_filename(t *testing.T) 
 		Body(bytes.NewBuffer([]byte(`file content`)))
 
 	err = feed.ExportInspectionReports(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	fileExists(t, filepath.Join(exporter.ExportPath, "audit_47ac0dce16f94d73b5178372368af162.pdf"))
 	fileExists(t, filepath.Join(exporter.ExportPath, "audit_4e28ab2cce8c44a781d376d0ac47dc92.pdf"))
@@ -139,7 +139,7 @@ func TestExportReports_should_not_run_if_all_exported(t *testing.T) {
 	defer gock.Off()
 
 	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "INSPECTION_TITLE")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
@@ -187,7 +187,7 @@ func TestExportReports_should_not_run_if_all_exported(t *testing.T) {
 		Body(bytes.NewBuffer([]byte(`file content`)))
 
 	err = feed.ExportInspectionReports(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	file1ModTime1, _ := getFileModTime(filepath.Join(exporter.ExportPath, "My-Audit.pdf"))
 	file2ModTime1, _ := getFileModTime(filepath.Join(exporter.ExportPath, "audit_2.pdf"))
@@ -196,7 +196,7 @@ func TestExportReports_should_not_run_if_all_exported(t *testing.T) {
 	// run the export process again
 	initMockFeedsSet1(apiClient.HTTPClient())
 	err = feed.ExportInspectionReports(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	file1ModTime2, _ := getFileModTime(filepath.Join(exporter.ExportPath, "My-Audit.pdf"))
 	file2ModTime2, _ := getFileModTime(filepath.Join(exporter.ExportPath, "audit_2.pdf"))
@@ -209,7 +209,7 @@ func TestExportReports_should_not_run_if_all_exported(t *testing.T) {
 
 func TestExportReports_should_take_care_of_invalid_file_names(t *testing.T) {
 	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "INSPECTION_TITLE")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
@@ -261,7 +261,7 @@ func TestExportReports_should_take_care_of_invalid_file_names(t *testing.T) {
 		BodyString(`{"activites": []}`)
 
 	err = feed.ExportInspectionReports(viperConfig, apiClient, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	fileExists(t, filepath.Join(exporter.ExportPath, "My-Audit-1.pdf"))
 	fileExists(t, filepath.Join(exporter.ExportPath, "My-Audit-1 (1).pdf"))
@@ -276,7 +276,7 @@ func TestExportReports_should_take_care_of_invalid_file_names(t *testing.T) {
 
 func TestExportReports_should_fail_after_retries(t *testing.T) {
 	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "INSPECTION_TITLE")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
@@ -316,7 +316,7 @@ func TestExportReports_should_fail_after_retries(t *testing.T) {
 
 func TestExportReports_should_fail_if_report_status_fails(t *testing.T) {
 	exporter, err := getTemporaryReportExporter([]string{"WORD"}, "", "INSPECTION_TITLE")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
@@ -356,7 +356,7 @@ func TestExportReports_should_fail_if_report_status_fails(t *testing.T) {
 
 func TestExportReports_should_fail_if_init_report_reply_is_not_success(t *testing.T) {
 	exporter, err := getTemporaryReportExporter([]string{"WORD"}, "", "INSPECTION_TITLE")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
@@ -389,7 +389,7 @@ func TestExportReports_should_fail_if_init_report_reply_is_not_success(t *testin
 
 func TestExportReports_should_fail_if_report_completion_reply_is_not_success(t *testing.T) {
 	exporter, err := getTemporaryReportExporter([]string{"WORD"}, "", "INSPECTION_TITLE")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
@@ -429,7 +429,7 @@ func TestExportReports_should_fail_if_report_completion_reply_is_not_success(t *
 
 func TestExportReports_should_fail_if_download_report_reply_is_not_success(t *testing.T) {
 	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "INSPECTION_TITLE")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
@@ -475,7 +475,7 @@ func TestExportReports_should_fail_if_download_report_reply_is_not_success(t *te
 
 func TestExportReports_should_return_error_for_unsupported_format(t *testing.T) {
 	exporter, err := getTemporaryReportExporter([]string{"PNG"}, "", "INSPECTION_TITLE")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 

--- a/internal/app/feed/exporter_schema_test.go
+++ b/internal/app/feed/exporter_schema_test.go
@@ -15,7 +15,7 @@ import (
 func TestSchemaWriter_should_write_schema(t *testing.T) {
 	var buf bytes.Buffer
 	exporter, err := feed.NewSchemaExporter(&buf)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
@@ -42,12 +42,12 @@ func TestSchemaWriter_should_write_schema(t *testing.T) {
 func TestSchemaWriter_should_write_all_schemas(t *testing.T) {
 	var buf bytes.Buffer
 	exporter, err := feed.NewSchemaExporter(&buf)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	viperConfig := viper.New()
 
 	err = feed.WriteSchemas(viperConfig, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.NotNil(t, buf.String())
 }

--- a/internal/app/feed/exporter_sql_intg_test.go
+++ b/internal/app/feed/exporter_sql_intg_test.go
@@ -1,3 +1,4 @@
+//go:build sql
 // +build sql
 
 package feed_test
@@ -12,14 +13,14 @@ import (
 
 func TestIntegrationDbSQLExporterLastModifiedAt_should_return_latest_modified_at(t *testing.T) {
 	exporter, err := getTestingSQLExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	inspectionFeed := &feed.InspectionFeed{}
 
 	err = exporter.InitFeed(inspectionFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	now := time.Now()
 	inspections := []feed.Inspection{
@@ -58,10 +59,10 @@ func TestIntegrationDbSQLExporterLastModifiedAt_should_return_latest_modified_at
 	}
 
 	err = exporter.WriteRows(inspectionFeed, inspections)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	lastModifiedAt, err := exporter.LastModifiedAt(inspectionFeed, time.Now().Add(time.Hour*-30000), "role_123")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, convery to ISO string
 	assert.Equal(t, now.Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
@@ -105,17 +106,17 @@ func TestIntegrationDbSQLExporterLastModifiedAt_should_return_latest_modified_at
 	}
 
 	err = exporter.WriteRows(inspectionFeed, inspections)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, time.Now().Add(time.Hour*-30000), "role_1234")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, convery to ISO string
 	assert.Equal(t, now.Add(time.Hour*-2).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 }
 
 func TestIntegrationDbSQLExporterInitFeed_integration_should_not_initialise_schemas_with_auto_migrate_disabled(t *testing.T) {
 	exporter, err := getTestingSQLExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	exporter.AutoMigrate = false
 
 	userFeed := &feed.UserFeed{}
@@ -123,7 +124,7 @@ func TestIntegrationDbSQLExporterInitFeed_integration_should_not_initialise_sche
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -139,14 +140,14 @@ func TestIntegrationDbSQLExporterInitFeed_integration_should_not_initialise_sche
 
 func TestIntegrationDbSQLExporterInitFeed_integration_should_initialise_schemas(t *testing.T) {
 	exporter, err := getTestingSQLExporter()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -157,5 +158,5 @@ func TestIntegrationDbSQLExporterInitFeed_integration_should_initialise_schemas(
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/internal/app/feed/exporter_sql_test.go
+++ b/internal/app/feed/exporter_sql_test.go
@@ -13,21 +13,21 @@ import (
 
 func TestSQLExporterSupportsUpsert_should_return_true(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.True(t, exporter.SupportsUpsert())
 }
 
 func TestSQLExporterInitFeed_should_create_table_if_not_exists(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// This query will only work for SQLite
 	result := []struct {
@@ -43,14 +43,14 @@ func TestSQLExporterInitFeed_should_create_table_if_not_exists(t *testing.T) {
 
 func TestSQLExporterInitFeed_should_truncate_table_if_truncate_is_true(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -61,12 +61,12 @@ func TestSQLExporterInitFeed_should_truncate_table_if_truncate_is_true(t *testin
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: true,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var rowCount int64
 	resp := exporter.DB.Table("users").Count(&rowCount)
@@ -76,14 +76,14 @@ func TestSQLExporterInitFeed_should_truncate_table_if_truncate_is_true(t *testin
 
 func TestSQLExporterInitFeed_should_not_truncate_table_if_truncate_is_false(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -94,12 +94,12 @@ func TestSQLExporterInitFeed_should_not_truncate_table_if_truncate_is_false(t *t
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var rowCount int64
 	resp := exporter.DB.Table("users").Count(&rowCount)
@@ -109,14 +109,14 @@ func TestSQLExporterInitFeed_should_not_truncate_table_if_truncate_is_false(t *t
 
 func TestSQLExporterWriteRows_should_write_rows(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -132,7 +132,7 @@ func TestSQLExporterWriteRows_should_write_rows(t *testing.T) {
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	rows := []feed.User{}
 	resp := exporter.DB.Table("users").Scan(&rows)
@@ -177,14 +177,14 @@ func TestSQLExporter_WriteRows_should_upsert_when_pk_conflict(t *testing.T) {
 
 func TestSQLExporterWriteRows_should_update_rows(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	userFeed := &feed.UserFeed{}
 
 	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
 		Truncate: true,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users := []feed.User{
 		{
@@ -195,7 +195,7 @@ func TestSQLExporterWriteRows_should_update_rows(t *testing.T) {
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	users = []feed.User{
 		{
@@ -206,7 +206,7 @@ func TestSQLExporterWriteRows_should_update_rows(t *testing.T) {
 	}
 
 	err = exporter.WriteRows(userFeed, users)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	rows := []feed.User{}
 	resp := exporter.DB.Table("users").Scan(&rows)
@@ -220,14 +220,14 @@ func TestSQLExporterWriteRows_should_update_rows(t *testing.T) {
 
 func TestSQLExporterLastModifiedAt_should_return_latest_modified_at(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	inspectionFeed := &feed.InspectionFeed{}
 
 	err = exporter.InitFeed(inspectionFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	now := time.Now()
 	inspections := []feed.Inspection{
@@ -250,16 +250,16 @@ func TestSQLExporterLastModifiedAt_should_return_latest_modified_at(t *testing.T
 	}
 
 	err = exporter.WriteRows(inspectionFeed, inspections)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check the timestamp for the audits that doesn't have organisation_id
 	lastModifiedAt, err := exporter.LastModifiedAt(inspectionFeed, time.Now().Add(time.Hour*-30000), "role_123")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, convery to ISO string
 	assert.Equal(t, now.Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, time.Now().Add(time.Hour*-30000), "role_1234")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, convery to ISO string
 	assert.Equal(t, now.Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
@@ -287,30 +287,30 @@ func TestSQLExporterLastModifiedAt_should_return_latest_modified_at(t *testing.T
 	}
 
 	err = exporter.WriteRows(inspectionFeed, inspections)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check the timestamp for the audits that contains organisation_id
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, time.Now().Add(time.Hour*-30000), "role_123")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, convery to ISO string
 	assert.Equal(t, now.Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, time.Now().Add(time.Hour*-30000), "role_1234")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, convery to ISO string
 	assert.Equal(t, now.Add(time.Hour*-2).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 }
 
 func TestSQLExporterLastModifiedAt_should_return_modified_after_if_latest(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	inspectionFeed := &feed.InspectionFeed{}
 
 	err = exporter.InitFeed(inspectionFeed, &feed.InitFeedOptions{
 		Truncate: false,
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	now := time.Now()
 	inspections := []feed.Inspection{
@@ -333,16 +333,16 @@ func TestSQLExporterLastModifiedAt_should_return_modified_after_if_latest(t *tes
 	}
 
 	err = exporter.WriteRows(inspectionFeed, inspections)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check the timestamp for the audits that doesn't have organisation_id
 	lastModifiedAt, err := exporter.LastModifiedAt(inspectionFeed, now.Add(time.Hour), "role_123")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, converting to ISO string
 	assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, now.Add(time.Hour), "role_124")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, converting to ISO string
 	assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
@@ -370,23 +370,23 @@ func TestSQLExporterLastModifiedAt_should_return_modified_after_if_latest(t *tes
 	}
 
 	err = exporter.WriteRows(inspectionFeed, inspections)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check the timestamp for the audits that contains organisation_id
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, now.Add(time.Hour), "role_123")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, converting to ISO string
 	assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 
 	lastModifiedAt, err = exporter.LastModifiedAt(inspectionFeed, now.Add(time.Hour), "role_124")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Times are slightly lossy, converting to ISO string
 	assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
 }
 
 func TestNewSQLExporter_should_create_exporter_for_sqlite(t *testing.T) {
 	sqlExporter, err := feed.NewSQLExporter("sqlite", "file::memory:", true, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.NotNil(t, sqlExporter)
 }
@@ -410,7 +410,7 @@ func TestSQLExporterWriteMedia(t *testing.T) {
 	}
 
 	sqlExporter, err := feed.NewSQLExporter("sqlite", "file::memory:", true, dir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	sqlExporter.WriteMedia("1234", "12345", "image/jpeg", []byte("sample-string"))
 }

--- a/internal/app/feed/feed_action_assignee_test.go
+++ b/internal/app/feed/feed_action_assignee_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestActionAssigneeFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	apiClient := api.GetTestClient()
 	initMockFeedsSet1(apiClient.HTTPClient())
@@ -24,7 +24,7 @@ func TestActionAssigneeFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	}
 
 	err = actionAssigneeFeed.Export(context.Background(), apiClient, exporter, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	rows := []feed.ActionAssignee{}
 	resp := exporter.DB.Table("action_assignees").Scan(&rows)

--- a/internal/app/feed/feed_actions_test.go
+++ b/internal/app/feed/feed_actions_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestActionFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	apiClient := api.GetTestClient()
 	initMockFeedsSet1(apiClient.HTTPClient())
@@ -22,7 +22,7 @@ func TestActionFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	}
 
 	err = actionsFeed.Export(context.Background(), apiClient, exporter, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	rows := []feed.Action{}
 	resp := exporter.DB.Table("actions").Scan(&rows)
@@ -34,7 +34,7 @@ func TestActionFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 
 func TestActionFeed_Export_ShouldNotFailWhen403(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	apiClient := api.GetTestClient()
 	gock.InterceptClient(apiClient.HTTPClient())
@@ -46,5 +46,5 @@ func TestActionFeed_Export_ShouldNotFailWhen403(t *testing.T) {
 		Limit: 100,
 	}
 	err = actionsFeed.Export(context.Background(), apiClient, exporter, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/internal/app/feed/feed_inspection_item_test.go
+++ b/internal/app/feed/feed_inspection_item_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestInspectionItemFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	apiClient := api.GetTestClient()
 	initMockFeedsSet1(apiClient.HTTPClient())
@@ -30,7 +30,7 @@ func TestInspectionItemFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	}
 
 	err = inspectionItemFeed.Export(context.Background(), apiClient, exporter, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	rows := []feed.InspectionItem{}
 	resp := exporter.DB.Table("inspection_items").Scan(&rows)
@@ -41,10 +41,10 @@ func TestInspectionItemFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 
 func TestInspectionItemFeedExportWithMedia(t *testing.T) {
 	dir, err := os.MkdirTemp("", "export")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	exporter, err := getInmemorySQLExporter(dir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	result := `{id:"test-id"}`
 	req := gock.New("http://localhost:9999").
@@ -68,5 +68,5 @@ func TestInspectionItemFeedExportWithMedia(t *testing.T) {
 	}
 
 	err = inspectionItemFeed.Export(context.Background(), apiClient, exporter, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/internal/app/feed/feed_inspection_test.go
+++ b/internal/app/feed/feed_inspection_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestInspectionFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	apiClient := api.GetTestClient()
 	initMockFeedsSet1(apiClient.HTTPClient())
@@ -35,7 +35,7 @@ func TestInspectionFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	}
 
 	err = inspectionsFeed.Export(context.Background(), apiClient, exporter, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	rows := []feed.Inspection{}
 	resp := exporter.DB.Table("inspections").Scan(&rows)

--- a/internal/app/feed/feed_issue_test.go
+++ b/internal/app/feed/feed_issue_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestIssueFeed_Export_ShouldExportRows(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	apiClient := api.GetTestClient()
 	defer resetMocks(apiClient.HTTPClient())
@@ -23,7 +23,7 @@ func TestIssueFeed_Export_ShouldExportRows(t *testing.T) {
 	}
 
 	err = actionsFeed.Export(context.Background(), apiClient, exporter, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var rows []feed.Issue
 	resp := exporter.DB.Table("issues").Scan(&rows)

--- a/internal/app/feed/utils_test.go
+++ b/internal/app/feed/utils_test.go
@@ -105,10 +105,10 @@ func getTestingSQLExporter() (*feed.SQLExporter, error) {
 // filesEqualish checks if files are equal enough (ignoring dates)
 func filesEqualish(t *testing.T, expectedPath, actualPath string) {
 	expectedFile, err := os.ReadFile(expectedPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	actualFile, err := os.ReadFile(actualPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t,
 		dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(expectedFile)), "--date--"),
@@ -118,7 +118,7 @@ func filesEqualish(t *testing.T, expectedPath, actualPath string) {
 
 func fileExists(t *testing.T, expectedPath string) {
 	_, err := os.Stat(expectedPath)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func getFileModTime(filePath string) (time.Time, error) {

--- a/internal/app/inspections/inspections_test.go
+++ b/internal/app/inspections/inspections_test.go
@@ -2,10 +2,11 @@ package inspections_test
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/SafetyCulture/safetyculture-exporter/internal/app/api"
 	exportermock "github.com/SafetyCulture/safetyculture-exporter/internal/app/exporter/mocks"
@@ -57,7 +58,7 @@ func TestInspectionsExport(t *testing.T) {
 		exporterMock,
 	)
 	err := inspectionClient.Export(context.Background())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInspectionsExport_WhenSkipID(t *testing.T) {
@@ -77,7 +78,7 @@ func TestInspectionsExport_WhenSkipID(t *testing.T) {
 	)
 	inspectionClient.(*inspections.Client).SkipIDs = []string{"audit_d7e2f55b95094bd48fac601850e1db63"}
 	err := inspectionClient.Export(context.Background())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInspectionsExport_WhenModifiedAtIsNotNil(t *testing.T) {
@@ -96,7 +97,7 @@ func TestInspectionsExport_WhenModifiedAtIsNotNil(t *testing.T) {
 		exporterMock,
 	)
 	err := inspectionClient.Export(context.Background())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestNewInspectionClient(t *testing.T) {


### PR DESCRIPTION
`assert.Nil` logs an error that is just a pointer ref. `assert.NoError` logs the actual error.