### PR TITLE
INTG-2620 process missing or corrupt yaml

### DIFF
--- a/cmd/safetyculture-exporter/cmd/export/export.go
+++ b/cmd/safetyculture-exporter/cmd/export/export.go
@@ -111,6 +111,9 @@ func runInspectionReports(cmd *cobra.Command, args []string) error {
 // NewSafetyCultureExporter create a new SafetyCultureExporter with configuration from Viper
 func NewSafetyCultureExporter(v *viper.Viper) *exporterAPI.SafetyCultureExporter {
 	cm, err := exporterAPI.NewConfigurationManagerFromFile("", v.ConfigFileUsed())
+	if err != nil {
+		util.Check(err, "failed to initialize the exporter")
+	}
 	MapViperConfigToExporterConfiguration(v, cm.Configuration)
 	cm.ApplySafetyGuards()
 	util.Check(err, "while loading config file")

--- a/cmd/safetyculture-exporter/cmd/root.go
+++ b/cmd/safetyculture-exporter/cmd/root.go
@@ -211,8 +211,5 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	err := viper.ReadInConfig()
-	if err != nil {
-		fmt.Println("Config file not found:", viper.ConfigFileUsed())
-	}
+	_ = viper.ReadInConfig()
 }

--- a/pkg/api/configuration_manager.go
+++ b/pkg/api/configuration_manager.go
@@ -136,10 +136,10 @@ func (c *ConfigurationManager) loadConfiguration() error {
 
 	yamlContents, err := os.ReadFile(filepath.Join(c.path, c.fileName))
 	if err != nil {
-		return fmt.Errorf("read file: %w", err)
+		return fmt.Errorf("cannot read the configuration file: %w", err)
 	}
 	if err := yaml.Unmarshal(yamlContents, c.Configuration); err != nil {
-		return fmt.Errorf("unmarshal file: %w", err)
+		return fmt.Errorf("configuration file is corrupt: %w", err)
 	}
 
 	return nil

--- a/pkg/api/configuration_manager_test.go
+++ b/pkg/api/configuration_manager_test.go
@@ -27,7 +27,7 @@ func TestNewConfigurationManagerFromFile_when_empty_filename(t *testing.T) {
 func TestNewConfigurationManagerFromFile_when_file_is_missing(t *testing.T) {
 	cm, err := api.NewConfigurationManagerFromFile("", "abc.yaml")
 	require.Nil(t, cm)
-	assert.Equal(t, "read file: open abc.yaml: no such file or directory", err.Error())
+	assert.Equal(t, "cannot read the configuration file: open abc.yaml: no such file or directory", err.Error())
 }
 
 func TestNewConfigurationManager_should_use_last_year_time(t *testing.T) {


### PR DESCRIPTION
better error messages when configuration file is missing or is corrupted