### PR TITLE
INTG-2689 Update Sheqsy UUID to size 36

### DIFF
--- a/pkg/internal/feed/feed_sheqsy_activity.go
+++ b/pkg/internal/feed/feed_sheqsy_activity.go
@@ -17,7 +17,7 @@ import (
 
 // SheqsyActivity represents a user in sheqsy
 type SheqsyActivity struct {
-	ActivityUID             string    `json:"activityUId" csv:"activity_uid" gorm:"primarykey;column:activity_uid;size:32"`
+	ActivityUID             string    `json:"activityUId" csv:"activity_uid" gorm:"primarykey;column:activity_uid;size:36"`
 	ActivityID              int       `json:"activityId" csv:"activity_id" gorm:"column:activity_id"`
 	ExternalID              *string   `json:"externalId" csv:"external_id" gorm:"column:external_id"`
 	Email                   string    `json:"email" csv:"email" gorm:"column:email"`

--- a/pkg/internal/feed/feed_sheqsy_department.go
+++ b/pkg/internal/feed/feed_sheqsy_department.go
@@ -14,7 +14,7 @@ import (
 
 // SheqsyDepartment represents a user in sheqsy
 type SheqsyDepartment struct {
-	DepartmentUID string    `json:"departmentUId" csv:"department_uid" gorm:"primarykey;column:department_uid;size:32"`
+	DepartmentUID string    `json:"departmentUId" csv:"department_uid" gorm:"primarykey;column:department_uid;size:36"`
 	DepartmentID  int       `json:"departmentId" csv:"department_id" gorm:"column:department_id"`
 	Name          string    `json:"name" csv:"name" gorm:"column:name"`
 	ExternalName  string    `json:"external_name" csv:"external_name" gorm:"column:external_name"`

--- a/pkg/internal/feed/feed_sheqsy_department_employee.go
+++ b/pkg/internal/feed/feed_sheqsy_department_employee.go
@@ -14,8 +14,8 @@ import (
 
 // SheqsyDepartmentEmployee represents a user in sheqsy
 type SheqsyDepartmentEmployee struct {
-	EmployeeUID   string    `json:"employeeUId" csv:"employee_uid" gorm:"primaryKey;column:employee_uid;size:32"`
-	DepartmentUID string    `json:"departmentUId" csv:"department_uid" gorm:"primaryKey;column:department_uid;size:32"`
+	EmployeeUID   string    `json:"employeeUId" csv:"employee_uid" gorm:"primaryKey;column:employee_uid;size:36"`
+	DepartmentUID string    `json:"departmentUId" csv:"department_uid" gorm:"primaryKey;column:department_uid;size:36"`
 	EmployeeID    int       `json:"employeeId" csv:"employee_id" gorm:"column:employee_id"`
 	DepartmentID  int       `json:"departmentId" csv:"department_id" gorm:"column:department_id"`
 	ExportedAt    time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`

--- a/pkg/internal/feed/feed_sheqsy_employee.go
+++ b/pkg/internal/feed/feed_sheqsy_employee.go
@@ -17,7 +17,7 @@ import (
 
 // SheqsyEmployee represents a user in sheqsy
 type SheqsyEmployee struct {
-	EmployeeUID             string    `json:"employeeUId" csv:"employee_uid" gorm:"primarykey;column:employee_uid;size:32"`
+	EmployeeUID             string    `json:"employeeUId" csv:"employee_uid" gorm:"primarykey;column:employee_uid;size:36"`
 	EmployeeID              int       `json:"employeeId" csv:"employee_id" gorm:"column:employee_id"`
 	ExternalID              *string   `json:"externalId" csv:"external_id" gorm:"column:external_id"`
 	FirstName               string    `json:"firstName" csv:"first_name" gorm:"column:first_name"`


### PR DESCRIPTION
- Update Sheqsy UUID to size 36, tested it with csv and the databases we currently support

https://user-images.githubusercontent.com/95192827/220221226-bb0e49f6-f4fe-4fea-8293-eb3ab74a6205.mov

- believe no user is using Sheqsy. This fix does the db column change directly but if the user did Sheqsy export before and has data already, they might see the following records, such as activity table.
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/95192827/220221407-b2dde0d8-0d38-466b-9cae-54f3d8b34a1f.png">
