### PR TITLE
[CSE-68] Mark deleted actions as deleted from export

### DIFF
--- a/pkg/api/mock_feeds_test.go
+++ b/pkg/api/mock_feeds_test.go
@@ -112,6 +112,12 @@ func initMockFeedsSet1(httpClient *http.Client) {
 		File(path.Join("mocks", "set_1", "inspections_deleted_single_page.json"))
 
 	gock.New("http://localhost:9999").
+		Post("/accounts/history/v1/activity_log/list").
+		BodyString(`{"org_id":"","page_size":0,"page_token":"","filters":{"timeframe":{"from":"0001-01-01T00:00:00Z"},"event_types":["action.actions_deleted"],"limit":0}}`).
+		Reply(http.StatusOK).
+		File(path.Join("mocks", "set_1", "actions_deleted_single_page.json"))
+
+	gock.New("http://localhost:9999").
 		Persist().
 		Get("/SheqsyIntegrationApi/api/v3/companies/ada3042f-16a4-4249-915d-dc088adef92a/employees").
 		Reply(200).

--- a/pkg/api/mocks/set_1/actions_deleted_single_page.json
+++ b/pkg/api/mocks/set_1/actions_deleted_single_page.json
@@ -1,0 +1,20 @@
+{
+  "activities": [
+    {
+      "id": "a7f7990e-a3d8-4985-b3c1-fb137b192a2c",
+      "event_at": "2022-07-05T01:02:10.887Z",
+      "type": "action.actions_deleted",
+      "user_id": "7d4f9200-bf23-4642-941b-248623bb586e",
+      "org_id": "30bafca8-9f56-4cbe-9e20-b2f4e586f238",
+      "client_class": "",
+      "agent": "",
+      "trace_id": "",
+      "metadata": {
+        "action_id_0": "123"
+      },
+      "remote_ip": "",
+      "initiator": "INITIATOR_USER"
+    }
+  ],
+  "next_page_token": ""
+}

--- a/pkg/api/mocks/set_1/outputs/actions.csv
+++ b/pkg/api/mocks/set_1/outputs/actions.csv
@@ -1,3 +1,3 @@
-action_id,title,description,site_id,priority,status,due_date,created_at,modified_at,exported_at,creator_user_id,creator_user_name,template_id,audit_id,audit_title,audit_item_id,audit_item_label,organisation_id,completed_at,action_label
-123,action 1,action 1 description,,LOW,COMPLETE,--date--,--date--,--date--,--date--,user_a,User A,,,,,,role_123,--date--,"{""label_id"":""fb209100-7351-43a9-a667-2478faa621ae""|""label_name"":""label""}"
-456,action 2,,site_123,LOW,TODO,--date--,--date--,--date--,--date--,user_b,User B,template_123,audit_123,Inspection title,872,Item title,role_123,--date--,"{""label_id"":""fb209100-7351-43a9-a667-2478faa621ae""|""label_name"":""label""}"
+action_id,title,description,site_id,priority,status,due_date,created_at,modified_at,exported_at,creator_user_id,creator_user_name,template_id,audit_id,audit_title,audit_item_id,audit_item_label,organisation_id,completed_at,action_label,deleted
+123,action 1,action 1 description,,LOW,COMPLETE,--date--,--date--,--date--,--date--,user_a,User A,,,,,,role_123,--date--,"{""label_id"":""fb209100-7351-43a9-a667-2478faa621ae""|""label_name"":""label""}",true
+456,action 2,,site_123,LOW,TODO,--date--,--date--,--date--,--date--,user_b,User B,template_123,audit_123,Inspection title,872,Item title,role_123,--date--,"{""label_id"":""fb209100-7351-43a9-a667-2478faa621ae""|""label_name"":""label""}",false

--- a/pkg/api/mocks/set_2/outputs/actions.csv
+++ b/pkg/api/mocks/set_2/outputs/actions.csv
@@ -1,3 +1,3 @@
-action_id,title,description,site_id,priority,status,due_date,created_at,modified_at,exported_at,creator_user_id,creator_user_name,template_id,audit_id,audit_title,audit_item_id,audit_item_label,organisation_id,completed_at,action_label
-123,action 1,action 1 description,,LOW,COMPLETE,--date--,--date--,--date--,--date--,user_a,User A,,,,,,role_123,--date--,"{""label_id"":""fb209100-7351-43a9-a667-2478faa621ae""|""label_name"":""label""}"
-456,action 2,,site_123,LOW,TODO,--date--,--date--,--date--,--date--,user_b,User B,template_123,audit_123,Inspection title,872,Item title,role_123,--date--,"{""label_id"":""fb209100-7351-43a9-a667-2478faa621ae""|""label_name"":""label""}"
+action_id,title,description,site_id,priority,status,due_date,created_at,modified_at,exported_at,creator_user_id,creator_user_name,template_id,audit_id,audit_title,audit_item_id,audit_item_label,organisation_id,completed_at,action_label,deleted
+123,action 1,action 1 description,,LOW,COMPLETE,--date--,--date--,--date--,--date--,user_a,User A,,,,,,role_123,--date--,"{""label_id"":""fb209100-7351-43a9-a667-2478faa621ae""|""label_name"":""label""}",false
+456,action 2,,site_123,LOW,TODO,--date--,--date--,--date--,--date--,user_b,User B,template_123,audit_123,Inspection title,872,Item title,role_123,--date--,"{""label_id"":""fb209100-7351-43a9-a667-2478faa621ae""|""label_name"":""label""}",false

--- a/pkg/api/utils_test.go
+++ b/pkg/api/utils_test.go
@@ -216,7 +216,7 @@ func TestClient_DrainDeletedInspections(t *testing.T) {
 
 	fakeTime, err := time.Parse(time.RFC3339, "2022-06-30T10:43:17Z")
 	require.Nil(t, err)
-	req := httpapi.NewGetAccountsActivityLogRequest(4, fakeTime)
+	req := httpapi.NewGetAccountsActivityLogRequest(4, fakeTime, []string{"inspection.deleted"})
 
 	calls := 0
 	var deletedIds = make([]string, 0, 15)
@@ -262,7 +262,7 @@ func TestClient_DrainDeletedInspections_WhenApiReturnsError(t *testing.T) {
 
 	fakeTime, err := time.Parse(time.RFC3339, "2022-06-30T10:43:17Z")
 	require.Nil(t, err)
-	req := httpapi.NewGetAccountsActivityLogRequest(14, fakeTime)
+	req := httpapi.NewGetAccountsActivityLogRequest(14, fakeTime, []string{"inspection.deleted"})
 	fn := func(res *httpapi.GetAccountsActivityLogResponse) error {
 		return nil
 	}
@@ -285,7 +285,7 @@ func TestClient_DrainDeletedInspections_WhenFeedFnReturnsError(t *testing.T) {
 
 	fakeTime, err := time.Parse(time.RFC3339, "2022-06-30T10:43:17Z")
 	require.Nil(t, err)
-	req := httpapi.NewGetAccountsActivityLogRequest(4, fakeTime)
+	req := httpapi.NewGetAccountsActivityLogRequest(4, fakeTime, []string{"inspection.deleted"})
 
 	fn := func(res *httpapi.GetAccountsActivityLogResponse) error {
 		return fmt.Errorf("ERROR_GetAccountsActivityLogResponse")

--- a/pkg/httpapi/models.go
+++ b/pkg/httpapi/models.go
@@ -77,7 +77,7 @@ type timeFrame struct {
 
 // NewGetAccountsActivityLogRequest build a request for AccountsActivityLog
 // for now it serves the purposes only for inspection.deleted. If we need later, we can change this builder
-func NewGetAccountsActivityLogRequest(pageSize int, from time.Time) *GetAccountsActivityLogRequestParams {
+func NewGetAccountsActivityLogRequest(pageSize int, from time.Time, events []string) *GetAccountsActivityLogRequestParams {
 	return &GetAccountsActivityLogRequestParams{
 		PageSize: pageSize,
 		Filters: accountsActivityLogFilter{
@@ -85,7 +85,7 @@ func NewGetAccountsActivityLogRequest(pageSize int, from time.Time) *GetAccounts
 				From: from,
 			},
 			Limit:      pageSize,
-			EventTypes: []string{"inspection.deleted"},
+			EventTypes: events,
 		},
 	}
 }

--- a/pkg/internal/feed/feed_inspection.go
+++ b/pkg/internal/feed/feed_inspection.go
@@ -240,7 +240,7 @@ func (f *InspectionFeed) processNewInspections(ctx context.Context, apiClient *h
 
 func (f *InspectionFeed) processDeletedInspections(ctx context.Context, apiClient *httpapi.Client, exporter Exporter) error {
 	lg := logger.GetLogger()
-	dreq := httpapi.NewGetAccountsActivityLogRequest(f.Limit, f.ModifiedAfter)
+	dreq := httpapi.NewGetAccountsActivityLogRequest(f.Limit, f.ModifiedAfter, []string{"inspection.deleted"})
 	delFn := func(resp *httpapi.GetAccountsActivityLogResponse) error {
 		var pkeys = make([]string, 0, len(resp.Activities))
 		for _, a := range resp.Activities {

--- a/pkg/internal/feed/fixtures/schemas/formatted/actions.txt
+++ b/pkg/internal/feed/fixtures/schemas/formatted/actions.txt
@@ -21,4 +21,5 @@
 | organisation_id   | TEXT     |             |
 | completed_at      | datetime |             |
 | action_label      | TEXT     |             |
+| deleted           | numeric  |             |
 +-------------------+----------+-------------+


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

This uses our activity log to capture deleted actions and mark them as deleted in the export.

## Problem description

As deleted actions are no longer returned in the data feeds, they remain in exported data sets.

## Pros/cons of approach implemented

## Checklist

<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->

- [ ] Is this PR a reasonable size?

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
