### PR TITLE
Add version back to log files

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/SafetyCulture/safetyculture-exporter/internal/app/version"
 	"github.com/SafetyCulture/safetyculture-exporter/pkg/internal/diagnostics"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -105,7 +106,7 @@ func getLogger(cores ...zapcore.Core) *zap.SugaredLogger {
 	)
 
 	// From a zapcore.Core, it's easy to construct a Logger.
-	l := zap.New(core).Named("safetyculture-exporter")
+	l := zap.New(core).Named(version.GetIntegrationID())
 	defer l.Sync()
 
 	// redirects output from the standard library's package-global logger to the supplied logger
@@ -113,6 +114,7 @@ func getLogger(cores ...zapcore.Core) *zap.SugaredLogger {
 
 	slg := l.Sugar().
 		With(
+			"version", version.GetVersion(),
 			"pid", os.Getpid(),
 			"uid", os.Getuid(),
 		)


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

This adds the exporter version back to the log files. This is useful when we are sent logs to know what version of the tool a customer is running.

## Problem description

<!-- Description of the problem being solved -->

## Pros/cons of approach implemented

## Checklist

<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->

- [ ] Is this PR a reasonable size?

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
