### PR TITLE
[CAPTURE-12136] Performance optimisation for inspections feeds for large organisations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PACKAGE_NAME        	:= "github.com/safetyculture/safetyculture-exporter"
 GOLANG_CROSS_VERSION  := v1.18.1
+NAME := safetyculture-exporter
 
 .PHONY: help
 help:
@@ -25,3 +26,10 @@ start-local-mssql:
 .PHONY: start-local-postgres
 start-local-postgres:
 	 docker-compose -f docker-compose-local-volume.yml up postgres
+
+.PHONY: build
+DIST_PATH=dist
+BUILD_OUTPUT_PATH=$(DIST_PATH)/$(NAME)
+build: ## Builds the executable for arch it is run on
+	rm -rf $(DIST_PATH)
+	go build -o ./$(BUILD_OUTPUT_PATH) ./cmd/$(NAME)

--- a/cmd/safetyculture-exporter/cmd/root.go
+++ b/cmd/safetyculture-exporter/cmd/root.go
@@ -115,6 +115,8 @@ func configFlags() {
 	exportFlags.String("export-path", "./export/", "File Export Path")
 	exportFlags.Bool("incremental", true, "Update inspections, inspection_items and templates tables incrementally")
 	exportFlags.String("modified-after", "", "Return inspections modified after this date (see readme for supported formats)")
+	exportFlags.String("modified-before", "", "Return inspections modified before this date (see readme for supported formats)")
+	exportFlags.String("block-size", "", "Split export into time blocks (e.g., \"1d\", \"1w\", \"1m\")")
 
 	mediaFlags = flag.NewFlagSet("media", flag.ContinueOnError)
 	mediaFlags.Bool("export-media", false, "Export media")
@@ -173,6 +175,8 @@ func bindFlags() {
 	util.Check(viper.BindPFlag("export.path", exportFlags.Lookup("export-path")), "while binding flag")
 	util.Check(viper.BindPFlag("export.incremental", exportFlags.Lookup("incremental")), "while binding flag")
 	util.Check(viper.BindPFlag("export.modified_after", exportFlags.Lookup("modified-after")), "while binding flag")
+	util.Check(viper.BindPFlag("export.inspection.modified_before", exportFlags.Lookup("modified-before")), "while binding flag")
+	util.Check(viper.BindPFlag("export.inspection.block_size", exportFlags.Lookup("block-size")), "while binding flag")
 
 	util.Check(viper.BindPFlag("export.media", mediaFlags.Lookup("export-media")), "while binding flag")
 	util.Check(viper.BindPFlag("export.media_path", mediaFlags.Lookup("export-media-path")), "while binding flag")

--- a/pkg/api/fixtures/invalid_block_size.yaml
+++ b/pkg/api/fixtures/invalid_block_size.yaml
@@ -1,0 +1,7 @@
+---
+access_token: "fake_token"
+api:
+  url: https://api.safetyculture.io
+export:
+  inspection:
+    block_size: "invalid_format"

--- a/pkg/api/fixtures/modified_before_after_conflict.yaml
+++ b/pkg/api/fixtures/modified_before_after_conflict.yaml
@@ -1,0 +1,8 @@
+---
+access_token: "fake_token"
+api:
+  url: https://api.safetyculture.io
+export:
+  modified_after: "2023-12-31T23:59:59Z"
+  inspection:
+    modified_before: "2023-01-01T00:00:00Z"

--- a/pkg/api/fixtures/valid_with_block_size.yaml
+++ b/pkg/api/fixtures/valid_with_block_size.yaml
@@ -1,0 +1,7 @@
+---
+access_token: "fake_token"
+api:
+  url: https://api.safetyculture.io
+export:
+  inspection:
+    block_size: "30d"

--- a/pkg/api/fixtures/valid_with_modified_before.yaml
+++ b/pkg/api/fixtures/valid_with_modified_before.yaml
@@ -1,0 +1,8 @@
+---
+access_token: "fake_token"
+api:
+  url: https://api.safetyculture.io
+export:
+  inspection:
+    modified_before: "2023-12-31T23:59:59Z"
+    block_size: "7d"

--- a/pkg/httpapi/models.go
+++ b/pkg/httpapi/models.go
@@ -32,11 +32,12 @@ type ListInspectionsResponse struct {
 
 // ListInspectionsParams is a list of all parameters we can set when fetching inspections
 type ListInspectionsParams struct {
-	ModifiedAfter time.Time `url:"modified_after,omitempty"`
-	TemplateIDs   []string  `url:"template,omitempty"`
-	Archived      string    `url:"archived,omitempty"`
-	Completed     string    `url:"completed,omitempty"`
-	Limit         int       `url:"limit,omitempty"`
+	ModifiedAfter  time.Time `url:"modified_after,omitempty"`
+	ModifiedBefore time.Time `url:"modified_before,omitempty"`
+	TemplateIDs    []string  `url:"template,omitempty"`
+	Archived       string    `url:"archived,omitempty"`
+	Completed      string    `url:"completed,omitempty"`
+	Limit          int       `url:"limit,omitempty"`
 }
 
 // InspectionReportExportCompletionResponse represents the response of report export completion status

--- a/pkg/internal/feed/drain_feed.go
+++ b/pkg/internal/feed/drain_feed.go
@@ -62,6 +62,7 @@ type PageFeedMetadata struct {
 // GetFeedParams is a list of all parameters we can set when fetching a feed
 type GetFeedParams struct {
 	ModifiedAfter   time.Time `url:"modified_after,omitempty"`
+	ModifiedBefore  time.Time `url:"modified_before,omitempty"`
 	TemplateIDs     []string  `url:"template,omitempty"`
 	Archived        string    `url:"archived,omitempty"`
 	Completed       string    `url:"completed,omitempty"`

--- a/pkg/internal/feed/feed_exporter.go
+++ b/pkg/internal/feed/feed_exporter.go
@@ -47,6 +47,8 @@ type ExporterFeedCfg struct {
 	SheqsyCompanyID                       string
 	ExportInspectionSkipIds               []string
 	ExportModifiedAfterTime               time.Time
+	ExportModifiedBeforeTime              time.Time
+	ExportBlockSize                       string
 	ExportTemplateIds                     []string
 	ExportInspectionArchived              string
 	ExportInspectionCompleted             string
@@ -286,6 +288,8 @@ func (e *ExporterFeedClient) GetFeeds() []Feed {
 			SkipIDs:         e.configuration.ExportInspectionSkipIds,
 			SkipFields:      e.configuration.ExportInspectionItemsSkipFields,
 			ModifiedAfter:   e.configuration.ExportModifiedAfterTime,
+			ModifiedBefore:  e.configuration.ExportModifiedBeforeTime,
+			BlockSize:       e.configuration.ExportBlockSize,
 			TemplateIDs:     e.configuration.ExportTemplateIds,
 			Archived:        e.configuration.ExportInspectionArchived,
 			Completed:       e.configuration.ExportInspectionCompleted,
@@ -324,14 +328,16 @@ func (e *ExporterFeedClient) GetFeeds() []Feed {
 
 func (e *ExporterFeedClient) getInspectionFeed() *InspectionFeed {
 	return &InspectionFeed{
-		SkipIDs:       e.configuration.ExportInspectionSkipIds,
-		ModifiedAfter: e.configuration.ExportModifiedAfterTime,
-		TemplateIDs:   e.configuration.ExportTemplateIds,
-		Archived:      e.configuration.ExportInspectionArchived,
-		Completed:     e.configuration.ExportInspectionCompleted,
-		Incremental:   e.configuration.ExportIncremental,
-		Limit:         e.configuration.ExportInspectionLimit,
-		WebReportLink: e.configuration.ExportInspectionWebReportLink,
+		SkipIDs:        e.configuration.ExportInspectionSkipIds,
+		ModifiedAfter:  e.configuration.ExportModifiedAfterTime,
+		ModifiedBefore: e.configuration.ExportModifiedBeforeTime,
+		BlockSize:      e.configuration.ExportBlockSize,
+		TemplateIDs:    e.configuration.ExportTemplateIds,
+		Archived:       e.configuration.ExportInspectionArchived,
+		Completed:      e.configuration.ExportInspectionCompleted,
+		Incremental:    e.configuration.ExportIncremental,
+		Limit:          e.configuration.ExportInspectionLimit,
+		WebReportLink:  e.configuration.ExportInspectionWebReportLink,
 	}
 }
 

--- a/pkg/internal/inspections/inspections.go
+++ b/pkg/internal/inspections/inspections.go
@@ -20,14 +20,16 @@ const maxGoRoutines = 10
 type Client struct {
 	*zap.SugaredLogger
 
-	apiClient     *httpapi.Client
-	exporter      exporter.SafetyCultureJSONExporter
-	SkipIDs       []string
-	ModifiedAfter time.Time
-	TemplateIDs   []string
-	Archived      string
-	Completed     string
-	Incremental   bool
+	apiClient      *httpapi.Client
+	exporter       exporter.SafetyCultureJSONExporter
+	SkipIDs        []string
+	ModifiedAfter  time.Time
+	ModifiedBefore time.Time
+	BlockSize      string
+	TemplateIDs    []string
+	Archived       string
+	Completed      string
+	Incremental    bool
 }
 
 // InspectionClient is an interface to get inspections from server
@@ -36,26 +38,30 @@ type InspectionClient interface {
 }
 
 type InspectionClientCfg struct {
-	SkipIDs       []string
-	ModifiedAfter time.Time
-	TemplateIDs   []string
-	Archived      string
-	Completed     string
-	Incremental   bool
+	SkipIDs        []string
+	ModifiedAfter  time.Time
+	ModifiedBefore time.Time
+	BlockSize      string
+	TemplateIDs    []string
+	Archived       string
+	Completed      string
+	Incremental    bool
 }
 
 // NewInspectionClient returns a new instance of InspectionClient
 func NewInspectionClient(cfg *InspectionClientCfg, apiClient *httpapi.Client, exporter exporter.SafetyCultureJSONExporter) InspectionClient {
 	return &Client{
-		apiClient:     apiClient,
-		exporter:      exporter,
-		SkipIDs:       cfg.SkipIDs,
-		ModifiedAfter: cfg.ModifiedAfter,
-		TemplateIDs:   cfg.TemplateIDs,
-		Archived:      cfg.Archived,
-		Completed:     cfg.Completed,
-		Incremental:   cfg.Incremental,
-		SugaredLogger: util2.GetLogger(),
+		apiClient:      apiClient,
+		exporter:       exporter,
+		SkipIDs:        cfg.SkipIDs,
+		ModifiedAfter:  cfg.ModifiedAfter,
+		ModifiedBefore: cfg.ModifiedBefore,
+		BlockSize:      cfg.BlockSize,
+		TemplateIDs:    cfg.TemplateIDs,
+		Archived:       cfg.Archived,
+		Completed:      cfg.Completed,
+		Incremental:    cfg.Incremental,
+		SugaredLogger:  util2.GetLogger(),
 	}
 }
 

--- a/pkg/internal/util/time_utils.go
+++ b/pkg/internal/util/time_utils.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"fmt"
+	"regexp"
+	"strconv"
 	"time"
 )
 
@@ -25,4 +28,86 @@ func TimeFromString(input string) (time.Time, error) {
 		return t, nil
 	}
 	return time.Time{}, lastErr
+}
+
+// ParseDuration parses duration strings like "1d", "7d", "1w", "1m", "3m", "1y"
+func ParseDuration(blockSize string) (time.Duration, error) {
+	if blockSize == "" {
+		return 0, fmt.Errorf("block size cannot be empty")
+	}
+
+	re := regexp.MustCompile(`^(\d+)([dwmy])$`)
+	matches := re.FindStringSubmatch(blockSize)
+	if len(matches) != 3 {
+		return 0, fmt.Errorf("invalid block size format: %s (expected format: 1d, 1w, 1m, 1y)", blockSize)
+	}
+
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid numeric value in block size: %s", matches[1])
+	}
+
+	if value <= 0 {
+		return 0, fmt.Errorf("block size value must be positive: %d", value)
+	}
+
+	unit := matches[2]
+	switch unit {
+	case "d":
+		return time.Duration(value) * 24 * time.Hour, nil
+	case "w":
+		return time.Duration(value) * 7 * 24 * time.Hour, nil
+	case "m":
+		return time.Duration(value) * 30 * 24 * time.Hour, nil
+	case "y":
+		return time.Duration(value) * 365 * 24 * time.Hour, nil
+	default:
+		return 0, fmt.Errorf("unsupported time unit: %s (supported: d, w, m, y)", unit)
+	}
+}
+
+// TimeBlock represents a time range with start and end times
+type TimeBlock struct {
+	Start time.Time
+	End   time.Time
+}
+
+// GenerateTimeBlocks splits a time range into blocks of specified size
+func GenerateTimeBlocks(start, end time.Time, blockSize time.Duration) []TimeBlock {
+	if start.After(end) || start.Equal(end) {
+		return []TimeBlock{}
+	}
+
+	var blocks []TimeBlock
+	current := start
+
+	for current.Before(end) {
+		blockEnd := current.Add(blockSize)
+		if blockEnd.After(end) {
+			blockEnd = end
+		}
+
+		blocks = append(blocks, TimeBlock{
+			Start: current,
+			End:   blockEnd,
+		})
+
+		current = blockEnd
+	}
+
+	return blocks
+}
+
+// GenerateTimeBlocksFromString convenience function using string duration
+func GenerateTimeBlocksFromString(start, end time.Time, blockSizeStr string) ([]TimeBlock, error) {
+	if blockSizeStr == "" {
+		return []TimeBlock{}, nil
+	}
+
+	blockSize, err := ParseDuration(blockSizeStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse block size: %w", err)
+	}
+
+	return GenerateTimeBlocks(start, end, blockSize), nil
 }

--- a/pkg/internal/util/time_utils_test.go
+++ b/pkg/internal/util/time_utils_test.go
@@ -3,6 +3,7 @@ package util_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/SafetyCulture/safetyculture-exporter/pkg/internal/util"
 	"github.com/stretchr/testify/assert"
@@ -65,4 +66,109 @@ func TestTimeFromString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseDuration(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected time.Duration
+		hasError bool
+	}{
+		"1 day": {
+			input:    "1d",
+			expected: 24 * time.Hour,
+		},
+		"7 days": {
+			input:    "7d",
+			expected: 7 * 24 * time.Hour,
+		},
+		"1 week": {
+			input:    "1w",
+			expected: 7 * 24 * time.Hour,
+		},
+		"2 weeks": {
+			input:    "2w",
+			expected: 14 * 24 * time.Hour,
+		},
+		"1 month": {
+			input:    "1m",
+			expected: 30 * 24 * time.Hour,
+		},
+		"3 months": {
+			input:    "3m",
+			expected: 90 * 24 * time.Hour,
+		},
+		"1 year": {
+			input:    "1y",
+			expected: 365 * 24 * time.Hour,
+		},
+		"empty string": {
+			input:    "",
+			hasError: true,
+		},
+		"invalid format": {
+			input:    "invalid",
+			hasError: true,
+		},
+		"zero value": {
+			input:    "0d",
+			hasError: true,
+		},
+		"negative value": {
+			input:    "-1d",
+			hasError: true,
+		},
+		"unsupported unit": {
+			input:    "1h",
+			hasError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := util.ParseDuration(test.input)
+			if test.hasError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, result)
+			}
+		})
+	}
+}
+
+func TestGenerateTimeBlocks(t *testing.T) {
+	start := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2023, 1, 8, 0, 0, 0, 0, time.UTC)
+	blockSize := 24 * time.Hour // 1 day
+
+	blocks := util.GenerateTimeBlocks(start, end, blockSize)
+
+	assert.Len(t, blocks, 7)
+	assert.Equal(t, start, blocks[0].Start)
+	assert.Equal(t, time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC), blocks[0].End)
+	assert.Equal(t, time.Date(2023, 1, 7, 0, 0, 0, 0, time.UTC), blocks[6].Start)
+	assert.Equal(t, end, blocks[6].End)
+}
+
+func TestGenerateTimeBlocksFromString(t *testing.T) {
+	start := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2023, 1, 4, 0, 0, 0, 0, time.UTC)
+
+	t.Run("valid block size", func(t *testing.T) {
+		blocks, err := util.GenerateTimeBlocksFromString(start, end, "1d")
+		require.NoError(t, err)
+		assert.Len(t, blocks, 3)
+	})
+
+	t.Run("empty block size", func(t *testing.T) {
+		blocks, err := util.GenerateTimeBlocksFromString(start, end, "")
+		require.NoError(t, err)
+		assert.Len(t, blocks, 0)
+	})
+
+	t.Run("invalid block size", func(t *testing.T) {
+		_, err := util.GenerateTimeBlocksFromString(start, end, "invalid")
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
**Note**: my first attempt at contributing to this repo; please point out anything I did wrong :) 

## Summary

Allows to specify two parameters specific for `inspections` and`inspection_items` feeds only: 
- `modified_before`: to only export items modified before a certain date
- `block_size`: splits the total export range into smaller blocks, and then exports inspections one block at a time. Possible values (does't have to be 1, any integer should work): 
  - `1d` for 1 day
  - `1w` for 1 week
  - `1m` for 1 month
  - `1y` for 1 year at a time

If none of the new parameters are specified, it keeps the existing behaviour.

## Problem description

When inspections API processes calls for the inspections or inspection items feed, as a part of the call it counts all inspections in the remaining range.

For large organisations and export start date several years in the past, the count statement can touch tens of millions of rows. It can get slow or in extreme cases fail with a timeout.

However, if we split the same range into smaller chunks, of, say, 1 day at a time, even for the largest organisations the count query will only touch a few thousand rows at most.

### Example: updates in config

```yaml
access_token: "<token>"
...
export:
...
  incremental: true
  inspection:
 ...
    modified_before: ""  # New, optional
    block_size: "1w"  # New, optional
...
```