### PR TITLE
PROBLEM-5597: Sanitise carriage returns.

### DIFF
--- a/pkg/internal/feed/exporter_report.go
+++ b/pkg/internal/feed/exporter_report.go
@@ -332,7 +332,7 @@ func (e *ReportExporter) saveReportResponse(resp io.ReadCloser, inspection *Insp
 func sanitizeName(name string) string {
 	res := strings.ReplaceAll(name, " / ", "-")
 	res = strings.ReplaceAll(res, " // ", "-")
-	var rx = regexp.MustCompile(`[/\\?%*:|"<> \t\n]`)
+	var rx = regexp.MustCompile(`[/\\?%*:|"<> \t\n\r]`)
 	res = rx.ReplaceAllString(res, "-")
 	return res
 }

--- a/pkg/internal/feed/exporter_report_test.go
+++ b/pkg/internal/feed/exporter_report_test.go
@@ -1,0 +1,60 @@
+package feed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "carriage return is removed",
+			input:    "Foo\rBar",
+			expected: "Foo-Bar",
+		},
+		{
+			name:     "CRLF is removed",
+			input:    "Foo\r\nBar",
+			expected: "Foo--Bar",
+		},
+		{
+			name:     "address with embedded CRLF line breaks",
+			input:    "Acme Corp, 10 High Street\r\n\r\n, W1A 1AA, - REF- 12345",
+			expected: "Acme-Corp,-10-High-Street----,-W1A-1AA,---REF--12345",
+		},
+		{
+			name:     "forward slashes are removed",
+			input:    "Test / Name // Here",
+			expected: "Test-Name-Here",
+		},
+		{
+			name:     "special characters are removed",
+			input:    "Name?with*special|chars:<>\"end",
+			expected: "Name-with-special-chars----end",
+		},
+		{
+			name:     "tabs and newlines are removed",
+			input:    "Name\twith\nnewlines",
+			expected: "Name-with-newlines",
+		},
+		{
+			name:     "plain name unchanged",
+			input:    "Simple-Name",
+			expected: "Simple-Name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeName(tt.input)
+			assert.Equal(t, tt.expected, result)
+			assert.NotContains(t, result, "\r")
+			assert.NotContains(t, result, "\n")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Sanitise carriage returns to fix this bug:

```
{"level":"error","ts":"2026-02-2xxxx","logger":"safetyculture-exporter","msg":"PDF export failed for 'audit_xxx'. Error: CreateFile export\\xxxx,-xxxx\r-\r-,-xxx-xxxx,---xxxx--xxxx.pdf: The filename, directory name, or volume label syntax is incorrect.","version":"xxxx","pid":xxxx,"uid":-1}
```

## Problem description
Windows computers use `\r` and our sanitiser did not handle this properly.

## Pros/cons of approach implemented

Pros:
- Handle `\r`
Cons:
- N/A

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
